### PR TITLE
Add cli args to print version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,11 +186,12 @@ dependencies = [
 
 [[package]]
 name = "bridge-cfg"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
  "ed25519-dalek 2.2.0",
+ "nym-bin-common",
  "nym-bridges",
  "nym-config",
  "rand 0.8.5",
@@ -207,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-tools"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -291,6 +292,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -401,6 +416,12 @@ name = "const-oid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+
+[[package]]
+name = "const-str"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
 
 [[package]]
 name = "core-foundation"
@@ -562,23 +583,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1331,8 +1352,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-bin-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym.git#846484bbb4c26b8eefdff350d551f6eb33b7d848"
+dependencies = [
+ "const-str",
+ "log",
+ "serde",
+ "vergen",
+]
+
+[[package]]
 name = "nym-bridge"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1344,6 +1376,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-slab",
+ "nym-bin-common",
  "nym-bridges",
  "once_cell",
  "pin-project-lite",
@@ -1373,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1417,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym.git#906dfb2fb044074ae744ad32d7f098d2e2127aa2"
+source = "git+https://github.com/nymtech/nym.git#846484bbb4c26b8eefdff350d551f6eb33b7d848"
 dependencies = [
  "dirs",
  "handlebars",
@@ -1432,9 +1465,9 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym.git#906dfb2fb044074ae744ad32d7f098d2e2127aa2"
+source = "git+https://github.com/nymtech/nym.git#846484bbb4c26b8eefdff350d551f6eb33b7d848"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "dotenvy",
  "log",
  "regex",
@@ -1856,13 +1889,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2855,6 +2888,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "vergen"
+version = "8.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.18.1",
+ "cfg-if",
+ "regex",
+ "rustc_version",
+ "rustversion",
+ "time",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,15 +3121,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3115,21 +3154,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -3152,12 +3176,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3170,12 +3188,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3185,12 +3197,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3212,12 +3218,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3227,12 +3227,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3248,12 +3242,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3263,12 +3251,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/bridge-cfg/Cargo.toml
+++ b/bridge-cfg/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 anyhow = "1.0.22"
 clap = { version = "4", features = ["derive", "string"] }
 ed25519-dalek = { version = "2.2", features = ["pkcs8", "alloc", "pem", "rand_core"]}
+nym-bin-common = {git = "https://github.com/nymtech/nym.git"}
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/bridge-cfg/src/main.rs
+++ b/bridge-cfg/src/main.rs
@@ -29,10 +29,12 @@
 
 use anyhow::Result;
 use clap::Parser;
+use nym_bin_common::bin_info;
 use nym_config::{DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILENAME, NYM_DIR, must_get_home};
 use tracing::*;
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 mod bridge_client_config;
 use bridge_client_config::BridgeClientConfig;
@@ -41,8 +43,14 @@ use bridge_config::BridgeConfig;
 mod node_config;
 use node_config::NodeConfig;
 
+static PRETTY_BUILD_INFORMATION: OnceLock<String> = OnceLock::new();
+// Helper for passing LONG_VERSION to clap
+fn pretty_build_info_static() -> &'static str {
+    PRETTY_BUILD_INFORMATION.get_or_init(|| bin_info!().pretty_print())
+}
+
 #[derive(Debug, Parser, PartialEq)]
-#[clap(name = "config-args")]
+#[command(author="Nymtech", version, long_version = pretty_build_info_static())]
 struct ConfigArgs {
     #[clap(short, long, conflicts_with = "id")]
     /// Provide a path to the `nym-node` configuration that will be used to populate the node

--- a/nym-bridge/Cargo.toml
+++ b/nym-bridge/Cargo.toml
@@ -14,6 +14,7 @@ getrandom = { version = "0.3", default-features = false }
 lru-slab = "0.1.2"
 lazy_static = "1"
 log = "0.4"
+nym-bin-common = {git = "https://github.com/nymtech/nym.git"}
 once_cell = "1.19"
 pin-project-lite = "0.2"
 quinn-proto = "0.11"

--- a/nym-bridge/src/main.rs
+++ b/nym-bridge/src/main.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
 use clap::Parser;
+use nym_bin_common::bin_info;
 use tokio::net::TcpStream;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::{net::SocketAddr, path::PathBuf};
 
 use nym_bridges::{
@@ -16,7 +17,7 @@ use nym_bridges::{
 };
 
 #[derive(Debug, Parser, PartialEq)]
-#[clap(name = "args")]
+#[command(author="Nymtech", version, long_version = pretty_build_info_static())]
 struct Args {
     #[clap(
         short = 'c',
@@ -26,6 +27,12 @@ struct Args {
     /// Specify the path to the config file to load. If no file path is provided, a default path
     /// will be assumed.
     config_path: PathBuf,
+}
+
+static PRETTY_BUILD_INFORMATION: OnceLock<String> = OnceLock::new();
+// Helper for passing LONG_VERSION to clap
+fn pretty_build_info_static() -> &'static str {
+    PRETTY_BUILD_INFORMATION.get_or_init(|| bin_info!().pretty_print())
 }
 
 #[tokio::main]


### PR DESCRIPTION
Add versioning info for `nym-bridge` and `bridge-cfg` tools.

example output:
```
$ bridge-cfg -V
bridge-cfg 0.1.2

$ bridge-cfg --version
bridge-cfg 
Binary Name:        bridge-cfg
Build Timestamp:    2025-10-27T17:29:27.385432338Z
Build Version:      0.1.2
Commit SHA:         846484bbb4c26b8eefdff350d551f6eb33b7d848
Commit Date:        2025-10-27T17:49:50.000000000+01:00
Commit Branch:      main
rustc Version:      1.90.0
rustc Channel:      stable
cargo Profile:      debug
```