### PR TITLE
Restrict publishing to the nym-bridges library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/nymtech/nym-bridges"
 homepage = "https://nymtech.net"
 readme = "README.md"
+# Whitelist what ships in the published crate. The package root is the repo
+# root, so without this the tarball would also bundle test-env/ (which holds
+# private ed25519 and WireGuard keys) plus tests/, pkg/, Dockerfile and .github.
+include = ["src/**/*.rs", "/README.md", "/LICENSE"]
 
 
 [workspace.dependencies]

--- a/bridge-cfg/Cargo.toml
+++ b/bridge-cfg/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bridge-cfg"
 version = "0.1.2"
 edition = "2024"
+publish = false
 authors = ["Nym Technologies SA"]
 description = "Configuration tooling for Nym transport bridges."
 license = "AGPL-3.0-only"

--- a/bridge-tools/Cargo.toml
+++ b/bridge-tools/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bridge-tools"
 version = "0.1.2"
 edition = "2024"
+publish = false
 authors = ["Nym Technologies SA"]
 description = "Client and debugging utilities for Nym transport bridges."
 license = "AGPL-3.0-only"

--- a/nym-bridge/Cargo.toml
+++ b/nym-bridge/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nym-bridge"
 version = "0.1.2"
 edition = "2024"
+publish = false
 authors = ["Nym Technologies SA"]
 description = "Server-side transparent forwarder that unwraps obfuscated Nym VPN bridge traffic."
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Remove test setups from crates publishing + only publish `nym-bridges` library crate 