### PR TITLE
Ed25519-Dalek and Rand bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "asn1-rs"
@@ -79,7 +79,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -91,7 +91,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -103,7 +103,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -169,11 +169,11 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "nym-bin-common",
  "nym-bridges",
  "nym-config",
- "rand 0.8.5",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -194,7 +194,7 @@ dependencies = [
  "bs58",
  "bytes",
  "clap",
- "ed25519-dalek 3.0.0-rc.1",
+ "ed25519-dalek",
  "getrandom 0.4.3",
  "hex",
  "lazy_static",
@@ -204,8 +204,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "quinn-proto",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.2",
+ "rand_chacha",
  "rcgen",
  "ring",
  "rustc-hash",
@@ -214,7 +214,7 @@ dependencies = [
  "serde",
  "slab",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -254,9 +254,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
@@ -301,7 +301,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -327,10 +327,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -338,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -350,14 +361,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -371,12 +382,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -425,35 +430,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
+ "rand_core 0.10.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -467,7 +458,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -478,23 +469,12 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -570,7 +550,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -587,51 +567,26 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0",
- "signature 3.0.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
-dependencies = [
- "curve25519-dalek 5.0.0-rc.1",
- "ed25519 3.0.0",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.10.0",
  "serde",
  "sha2 0.11.0",
- "signature 3.0.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -651,12 +606,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -687,9 +636,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -702,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -712,15 +661,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -729,38 +678,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -798,27 +747,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1317,7 +1255,7 @@ dependencies = [
  "base64",
  "bs58",
  "bytes",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "futures",
  "getrandom 0.4.3",
  "hex",
@@ -1327,7 +1265,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.10.2",
  "rcgen",
  "ring",
  "rustc-hash",
@@ -1337,7 +1275,7 @@ dependencies = [
  "serde_json",
  "slab",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1361,7 +1299,7 @@ dependencies = [
  "log",
  "nym-network-defaults",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "toml 0.8.23",
  "url",
 ]
@@ -1445,15 +1383,6 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
@@ -1497,7 +1426,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1524,22 +1453,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1595,7 +1514,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -1603,20 +1522,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1647,12 +1567,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1672,43 +1586,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1728,27 +1622,18 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "rcgen"
@@ -1790,7 +1675,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1887,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1911,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -1979,7 +1864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2025,7 +1910,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2036,14 +1921,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2131,18 +2016,13 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "similar"
@@ -2167,22 +2047,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
 ]
 
 [[package]]
@@ -2192,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der",
 ]
 
 [[package]]
@@ -2225,6 +2095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,7 +2122,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2265,11 +2146,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2280,18 +2161,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2386,7 +2267,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2401,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2411,6 +2292,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hashbrown 0.15.5",
+ "libc",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -2573,7 +2455,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2676,7 +2558,7 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2726,15 +2608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,7 +2653,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2815,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2942,12 +2815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +2834,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -3000,7 +2867,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3021,7 +2888,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3041,7 +2908,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3081,7 +2948,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1287,7 @@ dependencies = [
  "serde_json",
  "slab",
  "socket2",
+ "tempfile",
  "thiserror 2.0.19",
  "tinyvec",
  "tokio",
@@ -1795,6 +1808,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2159,19 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde_json = "1.0"
 similar = "3.1"
 slab = "0.4.6"
 socket2 = ">=0.5, <0.7"
+tempfile = "3"
 tempdir = "0.3"
 thiserror = "2.0"
 tinyvec = { version = "1.10", features = ["alloc"] }
@@ -146,6 +147,7 @@ tracing-subscriber = { workspace = true, default-features = false, features = [
     "time",
     "local-time",
 ] }
+tempfile.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.22.1"
 bs58 = "0.5.1"
 bytes = "1"
 clap = { version = "4", features = ["derive", "string"] }
-ed25519-dalek = { version = "3.0.0-pre.4", features = [
+ed25519-dalek = { version = "3.0", features = [
     "pkcs8",
     "alloc",
     "pem",
@@ -45,8 +45,8 @@ quinn = { version = "0.11", default-features = false, features = [
 quinn-proto = { version = "0.11", default-features = false, features = [
     "rustls",
 ] }
-rand = "0.9"
-rand_chacha = "0.9"
+rand = "0.10"
+rand_chacha = "0.10"
 rcgen = "0.14"
 ring = "0.17"
 rustc-hash = "2"
@@ -94,7 +94,7 @@ anyhow.workspace = true
 base64.workspace = true
 bs58.workspace = true
 bytes.workspace = true
-ed25519-dalek = { version = "2.2", features = [
+ed25519-dalek = { workspace=true, features = [
     "pkcs8",
     "alloc",
     "pem",
@@ -109,7 +109,7 @@ once_cell.workspace = true
 pin-project-lite.workspace = true
 quinn-proto.workspace = true
 quinn.workspace = true
-rand = "0.8"
+rand = {workspace = true, features = ["thread_rng", "sys_rng"]}
 rcgen.workspace = true
 ring.workspace = true
 rustc-hash.workspace = true

--- a/bridge-cfg/Cargo.toml
+++ b/bridge-cfg/Cargo.toml
@@ -12,13 +12,13 @@ homepage = "https://nymtech.net"
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }
-ed25519-dalek = { version = "2.2", features = [
+ed25519-dalek = { version = "3.0", features = [
 	"pkcs8",
 	"alloc",
 	"pem",
 	"rand_core",
 ] }
-rand = "0.8"
+rand = {workspace = true, features = ["thread_rng", "sys_rng"]}
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 similar.workspace = true

--- a/bridge-cfg/src/bridge_config.rs
+++ b/bridge-cfg/src/bridge_config.rs
@@ -76,8 +76,7 @@ impl BridgeConfig {
     /// material rather than trying to do it for them.
     pub fn generate_keys(&mut self, overwrite: bool, dir: &Path) -> Result<()> {
         debug!("generating keys overwrite:{overwrite}, dir: {dir:?}");
-        let mut rng = rand::thread_rng();
-        let new_key = SigningKey::generate(&mut rng);
+        let new_key = SigningKey::generate(&mut rand::rng());
         let key = new_key
             .to_pkcs8_pem(LineEnding::CRLF)
             .context("failed to serialize ed25519 private key to PKCS8 PEM")?

--- a/bridge-tools/src/udp_recv.rs
+++ b/bridge-tools/src/udp_recv.rs
@@ -9,7 +9,7 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
 use clap::Parser;
-use rand::{SeedableRng, RngExt};
+use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::collections::HashSet;
 use tokio::{net::UdpSocket, time::Instant};

--- a/bridge-tools/src/udp_recv.rs
+++ b/bridge-tools/src/udp_recv.rs
@@ -9,7 +9,7 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
 use clap::Parser;
-use rand::{Rng, SeedableRng};
+use rand::{SeedableRng, RngExt};
 use rand_chacha::ChaCha20Rng;
 use std::collections::HashSet;
 use tokio::{net::UdpSocket, time::Instant};
@@ -137,7 +137,7 @@ impl Generator {
     fn new(size: Size, count: usize, seed: Option<u64>) -> Self {
         let rng = match seed {
             Some(s) => rand_chacha::ChaCha20Rng::seed_from_u64(s),
-            None => rand_chacha::ChaCha20Rng::from_os_rng(),
+            None => rand_chacha::ChaCha20Rng::from_rng(&mut rand::rng()),
         };
 
         Self {

--- a/bridge-tools/src/udp_sender.rs
+++ b/bridge-tools/src/udp_sender.rs
@@ -167,7 +167,7 @@ impl Generator {
         };
         let rng = match seed {
             Some(s) => rand_chacha::ChaCha20Rng::seed_from_u64(s),
-            None => rand_chacha::ChaCha20Rng::from_os_rng(),
+            None => rand_chacha::ChaCha20Rng::from_rng(&mut rand::rng()),
         };
         if match size {
             Size::Fixed(s) => s < 4,

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -1,5 +1,9 @@
-use std::path::PathBuf;
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, anyhow};
 use base64::prelude::*;
@@ -53,7 +57,7 @@ impl ServerConfig {
         if let Some(ref base64_key) = self.identity_key {
             ServerConfigSource::from_identity_base64(base64_key)
         } else if let Some(ref key_path) = self.private_ed25519_identity_key_file {
-            let signing_key = SigningKey::read_pkcs8_pem_file(key_path)
+            let signing_key = read_pkcs8_pem_file(key_path)
                 .map_err(|e| anyhow!("failed to parse identity key in {key_path:?}: {e}"))?;
             Ok(ServerConfigSource::from_identity(signing_key.to_bytes()))
         } else {
@@ -71,6 +75,11 @@ impl ServerConfig {
         let public_id = crypto_source.public_identity();
         Ok(BASE64_STANDARD.encode(&public_id[..]))
     }
+}
+
+fn read_pkcs8_pem_file<P: AsRef<Path>>(path: P) -> Result<SigningKey> {
+    let str = &fs::read_to_string(path)?;
+    SigningKey::from_pkcs8_pem(str).context("failed to parse pem file")
 }
 
 pub fn create_endpoint(options: &ServerConfig) -> Result<quinn::Endpoint> {

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -1,14 +1,8 @@
-use std::{
-    fs,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
 use base64::prelude::*;
-use ed25519_dalek::pkcs8::DecodePrivateKey;
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::VerifyingKey;
 use quinn_proto::crypto::rustls::QuicClientConfig;
 use quinn_proto::crypto::rustls::QuicServerConfig;
 use serde::{Deserialize, Serialize};
@@ -57,9 +51,7 @@ impl ServerConfig {
         if let Some(ref base64_key) = self.identity_key {
             ServerConfigSource::from_identity_base64(base64_key)
         } else if let Some(ref key_path) = self.private_ed25519_identity_key_file {
-            let signing_key = read_pkcs8_pem_file(key_path)
-                .map_err(|e| anyhow!("failed to parse identity key in {key_path:?}: {e}"))?;
-            Ok(ServerConfigSource::from_identity(signing_key.to_bytes()))
+            ServerConfigSource::from_pkcs8_pem_file(key_path)
         } else {
             Err(anyhow!("no crypto source provided"))
         }
@@ -75,11 +67,6 @@ impl ServerConfig {
         let public_id = crypto_source.public_identity();
         Ok(BASE64_STANDARD.encode(&public_id[..]))
     }
-}
-
-fn read_pkcs8_pem_file<P: AsRef<Path>>(path: P) -> Result<SigningKey> {
-    let str = &fs::read_to_string(path)?;
-    SigningKey::from_pkcs8_pem(str).context("failed to parse pem file")
 }
 
 pub fn create_endpoint(options: &ServerConfig) -> Result<quinn::Endpoint> {

--- a/src/transport/tls/certs.rs
+++ b/src/transport/tls/certs.rs
@@ -23,10 +23,10 @@
 //!     - done last to avoid ed25519 signature verification in case string based checks fail
 //!   - uses the default [`rustls::client::WebPkiServerVerifier`] to verify TLS 1.2 / TLS 1.3
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use base64::prelude::*;
 use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
-use ed25519_dalek::pkcs8::{DecodePublicKey, EncodePrivateKey};
+use ed25519_dalek::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use rcgen::{Certificate, CertificateParams, DnType, KeyPair};
 use rustls::client::WebPkiServerVerifier;
@@ -37,7 +37,7 @@ use tracing::*;
 use webpki_roots::TLS_SERVER_ROOTS;
 use x509_parser::prelude::*;
 
-use std::sync::Arc;
+use std::{fmt::Debug, fs, path::Path, sync::Arc};
 
 pub fn get_cert_signed_by_ed25519<'a>(
     common_name: String,
@@ -274,6 +274,13 @@ impl ServerConfigSource {
         Ok(Self::from_identity(bytes))
     }
 
+    pub fn from_pkcs8_pem_file<P: AsRef<Path> + Debug>(path: P) -> Result<Self> {
+        let pem = fs::read_to_string(path.as_ref())?;
+        let signing_key = SigningKey::from_pkcs8_pem(&pem)
+            .map_err(|e| anyhow!("failed to parse identity key in {path:?}: {e}"))?;
+        Ok(Self::from_identity(signing_key.to_bytes()))
+    }
+
     pub fn into_server_config(self) -> Result<rustls::ServerConfig> {
         let key_bytes = self.0;
         info!("initializing from transport identity keypair");
@@ -298,9 +305,12 @@ impl ServerConfigSource {
 
 #[cfg(test)]
 mod test {
-    use rustls_pki_types::DnsName;
-
     use super::*;
+    use ed25519_dalek::SigningKey;
+    use ed25519_dalek::pkcs8::{EncodePrivateKey, spki::der::pem::LineEnding};
+    use rustls_pki_types::DnsName;
+    use std::fs;
+    use tempfile::NamedTempFile;
 
     /// Make sure that client connection using domain name not signed by the
     /// identity key derived cert gives an InvalidCertificate(NotValidForName) error.
@@ -446,6 +456,24 @@ mod test {
         assert!(
             handshake_complete,
             "Handshake did not complete within {MAX_ITERATIONS} iterations",
+        );
+    }
+
+    #[test]
+    fn read_pkcs8_pem_file_parses_valid_ed25519_key() {
+        let expected_key = SigningKey::from_bytes(&[7u8; ed25519_dalek::SECRET_KEY_LENGTH]);
+        let pem = expected_key
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("failed to encode key as PKCS8 PEM");
+
+        let pem_file = NamedTempFile::new().expect("failed to create temporary PEM file");
+        fs::write(pem_file.path(), pem.as_bytes()).expect("failed to write temporary PEM file");
+
+        let source = ServerConfigSource::from_pkcs8_pem_file(pem_file.path())
+            .expect("failed to parse PEM file");
+        assert_eq!(
+            source.public_identity(),
+            expected_key.verifying_key().to_bytes()
         );
     }
 }

--- a/src/transport/tls/certs.rs
+++ b/src/transport/tls/certs.rs
@@ -309,9 +309,7 @@ mod test {
         // let level = Some(tracing::level_filters::LevelFilter::DEBUG);
         // crate::test_utils::init_subscriber(level);
 
-        let mut rng = rand::thread_rng();
-
-        let signing_key: SigningKey = SigningKey::generate(&mut rng);
+        let signing_key: SigningKey = SigningKey::generate(&mut rand::rng());
         let verif_key = signing_key.verifying_key();
         let encoded_pubkey = bs58::encode(verif_key.to_bytes()).into_string();
 
@@ -366,9 +364,7 @@ mod test {
         // let level = Some(tracing::level_filters::LevelFilter::DEBUG);
         // crate::test_utils::init_subscriber(level);
 
-        let mut rng = rand::thread_rng();
-
-        let signing_key: SigningKey = SigningKey::generate(&mut rng);
+        let signing_key: SigningKey = SigningKey::generate(&mut rand::rng());
         let verif_key = signing_key.verifying_key();
         let encoded_pubkey = bs58::encode(verif_key.to_bytes()).into_string();
 

--- a/src/transport/tls/mod.rs
+++ b/src/transport/tls/mod.rs
@@ -1,5 +1,9 @@
-use std::path::PathBuf;
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, anyhow};
 use base64::Engine;
@@ -52,7 +56,7 @@ impl ServerConfig {
         if let Some(ref base64_key) = self.identity_key {
             ServerConfigSource::from_identity_base64(base64_key)
         } else if let Some(ref key_path) = self.private_ed25519_identity_key_file {
-            let signing_key = SigningKey::read_pkcs8_pem_file(key_path)
+            let signing_key = read_pkcs8_pem_file(key_path)
                 .map_err(|e| anyhow!("failed to parse identity key in {key_path:?}: {e}"))?;
             Ok(ServerConfigSource::from_identity(signing_key.to_bytes()))
         } else {
@@ -70,6 +74,11 @@ impl ServerConfig {
         let public_id = crypto_source.public_identity();
         Ok(BASE64_STANDARD.encode(&public_id[..]))
     }
+}
+
+fn read_pkcs8_pem_file<P: AsRef<Path>>(path: P) -> Result<SigningKey> {
+    let str = &fs::read_to_string(path)?;
+    SigningKey::from_pkcs8_pem(str).context("failed to parse pem file")
 }
 
 pub fn create_listener(options: &ServerConfig) -> Result<TlsAcceptor> {

--- a/src/transport/tls/mod.rs
+++ b/src/transport/tls/mod.rs
@@ -1,23 +1,16 @@
-use std::{
-    fs,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use ed25519_dalek::pkcs8::DecodePrivateKey;
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::VerifyingKey;
 use rustls::pki_types::ServerName;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 use tracing::*;
 
-use crate::transport::tls::certs::IdentityBasedVerifier;
-use crate::transport::tls::certs::ServerConfigSource;
+use crate::transport::tls::certs::{IdentityBasedVerifier, ServerConfigSource};
 
 pub(crate) mod certs;
 
@@ -56,9 +49,7 @@ impl ServerConfig {
         if let Some(ref base64_key) = self.identity_key {
             ServerConfigSource::from_identity_base64(base64_key)
         } else if let Some(ref key_path) = self.private_ed25519_identity_key_file {
-            let signing_key = read_pkcs8_pem_file(key_path)
-                .map_err(|e| anyhow!("failed to parse identity key in {key_path:?}: {e}"))?;
-            Ok(ServerConfigSource::from_identity(signing_key.to_bytes()))
+            ServerConfigSource::from_pkcs8_pem_file(key_path)
         } else {
             Err(anyhow!("no crypto source provided"))
         }
@@ -74,11 +65,6 @@ impl ServerConfig {
         let public_id = crypto_source.public_identity();
         Ok(BASE64_STANDARD.encode(&public_id[..]))
     }
-}
-
-fn read_pkcs8_pem_file<P: AsRef<Path>>(path: P) -> Result<SigningKey> {
-    let str = &fs::read_to_string(path)?;
-    SigningKey::from_pkcs8_pem(str).context("failed to parse pem file")
 }
 
 pub fn create_listener(options: &ServerConfig) -> Result<TlsAcceptor> {

--- a/tests/sender/mod.rs
+++ b/tests/sender/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::*;
 
-use rand::Rng;
+use rand::RngExt;
 use tokio::net::UdpSocket;
 use tokio::time::sleep;
 
@@ -88,7 +88,7 @@ impl Generator {
             count,
             n_sent: 0,
             last_send: None,
-            rng: rand::thread_rng(),
+            rng: rand::rng(),
             packet_pool: PacketPool::new(10, max_size), // Pool of 10 buffers
         }
     }
@@ -127,7 +127,7 @@ impl Generator {
                 Rate::Random { min, max } => {
                     let min_nanos = min.as_nanos() as u64;
                     let max_nanos = max.as_nanos() as u64;
-                    let random_nanos = self.rng.gen_range(min_nanos..=max_nanos);
+                    let random_nanos = self.rng.random_range(min_nanos..=max_nanos);
                     Duration::from_nanos(random_nanos)
                 }
             };
@@ -144,7 +144,7 @@ impl Generator {
     fn generate_size(&mut self) -> usize {
         match &self.size {
             Size::Fixed(size) => *size,
-            Size::Random { min, max } => self.rng.gen_range(*min..=*max),
+            Size::Random { min, max } => self.rng.random_range(*min..=*max),
             Size::Gradient { min, max, n } => {
                 let progress = (self.n_sent % n) as f64 / *n as f64;
                 let size_range = *max - *min;


### PR DESCRIPTION
Now that there is a stable release of `ed25519-dalek` 3.0 swap over to using that and also update rand and related dependencies. 

In order to do this there is a small adition of file handling for the PEM PCS8 parsing based on changes to exposed APIs relating to cert parsing in `pkcs8` and `ed25519-dalek`


This PR 
- closes https://github.com/nymtech/nym-bridges/issues/18
- closes https://github.com/nymtech/nym-bridges/pull/13
- closes https://github.com/nymtech/nym-bridges/pull/22
- related to https://github.com/nymtech/nym-bridges/pull/39