### PR TITLE
Use only snake case for config type serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cfg"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-tools"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "nym-bridge"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges-types"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [workspace.package]
 authors = ["Nym Technologies SA"]
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2024"
 repository = "https://github.com/nymtech/nym-bridges"
 homepage = "https://nymtech.net"

--- a/crates/nym-bridges-types/src/lib.rs
+++ b/crates/nym-bridges-types/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - This crate contains all types necessary for interaction with crates (nym-vpn-lib-types) and others
 //! - Types visible via bindings should contain proper attributes and feature gated to `uniffi-bindings` for uniffi, `typescript-bindings` for TypeScript bindings.
-//! - TypeScript bindings use serde for conversion from Rust to TS and feature-gated to `typescript-bindings`. Camel case is preferred for compatibility with TypeScript/Tauri.
+//! - TypeScript bindings use serde for conversion from Rust to TS and feature-gated to `typescript-bindings`.
 //! - Be mindful of limitations of TypeScript and uniffi limitations. Keep exported types simple.
 //!
 //! ## Dependency considerations
@@ -20,8 +20,8 @@
 //! - Namespaces are not supported, all exported types should have unique names.
 //! - Not all types are supported or can be bridged. Keep exported types simple.
 //!
-//! 2. TypeScript bindings using [ts-rs](https://docs.rs/ts-rs) (feature flag: typescript-bindings). Serialization (using serde) uses snake_case because initial version of
-//! the configs for deployed in mainnet bridges use snake_case. This will likely be fixed in a future version of the config types.
+//! 2. TypeScript bindings using [ts-rs](https://docs.rs/ts-rs) (feature flag: `typescript-bindings`). Serialization ([using serde](https://docs.rs/serde)) uses `snake_case`.
+//! 
 //!    Run the following command to generate TypeScript bindings:
 //!    ```sh
 //!    cargo test -p nym-vpn-lib-types -F typescript-bindings
@@ -29,7 +29,7 @@
 //!
 //! ## Serde support
 //!
-//! Serde can be enabled using `serde` feature flag. Note that TypeScript adds camelCase transformation for keys. Do not mix both feature flags in the same workspace.
+//! Serde can be enabled using `serde` feature flag. 
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/nym-bridges-types/src/lib.rs
+++ b/crates/nym-bridges-types/src/lib.rs
@@ -20,7 +20,8 @@
 //! - Namespaces are not supported, all exported types should have unique names.
 //! - Not all types are supported or can be bridged. Keep exported types simple.
 //!
-//! 2. TypeScript bindings using [ts-rs](https://docs.rs/ts-rs) (feature flag: typescript-bindings). Serialization (using serde) uses camelCase for compatibility with TypeScript/Tauri.
+//! 2. TypeScript bindings using [ts-rs](https://docs.rs/ts-rs) (feature flag: typescript-bindings). Serialization (using serde) uses snake_case because initial version of
+//! the configs for deployed in mainnet bridges use snake_case. This will likely be fixed in a future version of the config types.
 //!    Run the following command to generate TypeScript bindings:
 //!    ```sh
 //!    cargo test -p nym-vpn-lib-types -F typescript-bindings
@@ -58,11 +59,7 @@ uniffi::custom_type!(SocketAddr, String, {
     ts(export),
     ts(export_to = "bindings.ts")
 )]
-#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
-#[cfg_attr(
-    all(feature = "serde", not(feature = "typescript-bindings")),
-    serde(rename_all = "snake_case")
-)]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub struct PersistedClientConfig {
     pub version: String,
     pub transports: Vec<ClientConfig>,
@@ -91,11 +88,7 @@ impl PersistedClientConfig {
     ts(export),
     ts(export_to = "bindings.ts")
 )]
-#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
-#[cfg_attr(
-    all(feature = "serde", not(feature = "typescript-bindings")),
-    serde(rename_all = "snake_case")
-)]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum ClientConfig {
     QuicPlain(quic::ClientOptions),
     TlsPlain(tls::ClientOptions),
@@ -130,11 +123,7 @@ pub mod quic {
         ts(export),
         ts(export_to = "bindings.ts")
     )]
-    #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
-    #[cfg_attr(
-        all(feature = "serde", not(feature = "typescript-bindings")),
-        serde(rename_all = "snake_case")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     pub struct QuicPlainClientOptions {
         /// Address describing the remote transport server. This is a vec to support multiple addresses
         /// so as to support both IPv4 and IPv6. These addresses are meant to describe a single bridge
@@ -170,11 +159,7 @@ pub mod tls {
         ts(export),
         ts(export_to = "bindings.ts")
     )]
-    #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
-    #[cfg_attr(
-        all(feature = "serde", not(feature = "typescript-bindings")),
-        serde(rename_all = "snake_case")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     pub struct TlsPlainClientOptions {
         /// Address describing the remote transport server. This is a vec to support multiple addresses
         /// so as to support both IPv4 and IPv6. These addresses are meant to describe a single bridge
@@ -195,29 +180,32 @@ pub mod tls {
 
 #[cfg(test)]
 mod test {
+    use crate::{ClientConfig, PersistedClientConfig};
+
     const RAW_V0_CLIENT_CONFIG: &str = r#"{"version":"0","transports":[{"transport_type":"quic_plain","args":{"addresses":["139.162.33.226:4443","[2400:8901::2000:faff:fea6:87f2]:4443"],"host":"netdna.bootstrapcdn.com","id_pubkey":"9JC91ZiszhIn3n4FG+MDYE/lYwhGdpHGWQTKUqGl+sE="}}]}"#;
 
+    /// The initial version of the bridge descriptors that are provided by the gateways use a snake case
+    /// for the enum differentiator. This test validates that under normal circumstances that the descriptor
+    /// is parsed as  expected. The only situation under which the enum differentiator has a different format
+    /// is when using the `typescript-bindings` feature.
     #[test]
-    fn ensure_v0_parsing_compatibility() -> Result<(), Box<dyn std::error::Error>> {
+    fn ensure_bridge_v0_parsing_compatibility() -> Result<(), Box<dyn std::error::Error>> {
         // Parse the JSON to verify structure
-        let parsed: serde_json::Value = serde_json::from_str(RAW_V0_CLIENT_CONFIG)?;
+        let parsed: PersistedClientConfig = serde_json::from_str(RAW_V0_CLIENT_CONFIG)?;
 
         // Verify version
-        assert_eq!(parsed["version"], "0");
+        assert_eq!(parsed.version, "0");
 
         // Verify transport type
-        assert_eq!(parsed["transports"][0]["transport_type"], "quic_plain");
+        let params = match &parsed.transports[0] {
+            ClientConfig::QuicPlain(p) => p,
+            ClientConfig::TlsPlain(_) => return Err("expected quic transport args".into()),
+        };
 
         // Verify addresses contain our test IPs
-        let addresses = &parsed["transports"][0]["args"]["addresses"];
-        assert!(addresses.is_array());
+        let addresses = &params.addresses;
 
-        let address_strings: Vec<String> = addresses
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|v| v.as_str().unwrap().to_string())
-            .collect();
+        let address_strings: Vec<String> = addresses.iter().map(|v| v.to_string()).collect();
 
         // Should contain both IPv4 and IPv6 addresses with port 4443
         assert!(
@@ -232,10 +220,7 @@ mod test {
         );
 
         // Verify host field
-        assert_eq!(
-            parsed["transports"][0]["args"]["host"],
-            "netdna.bootstrapcdn.com"
-        );
+        assert_eq!(params.host, Some("netdna.bootstrapcdn.com".to_string()),);
 
         Ok(())
     }

--- a/crates/nym-bridges-types/src/lib.rs
+++ b/crates/nym-bridges-types/src/lib.rs
@@ -21,7 +21,7 @@
 //! - Not all types are supported or can be bridged. Keep exported types simple.
 //!
 //! 2. TypeScript bindings using [ts-rs](https://docs.rs/ts-rs) (feature flag: `typescript-bindings`). Serialization ([using serde](https://docs.rs/serde)) uses `snake_case`.
-//! 
+//!
 //!    Run the following command to generate TypeScript bindings:
 //!    ```sh
 //!    cargo test -p nym-vpn-lib-types -F typescript-bindings
@@ -29,7 +29,7 @@
 //!
 //! ## Serde support
 //!
-//! Serde can be enabled using `serde` feature flag. 
+//! Serde can be enabled using `serde` feature flag.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/nym-bridges/src/lib.rs
+++ b/crates/nym-bridges/src/lib.rs
@@ -22,18 +22,25 @@
 //!
 //! # Example: Simple Client Connection Establishment
 //!
-//! ```
+//! ```rust no_run
+//! # #[tokio::main]
+//! # async fn main() -> Result<(),anyhow::Error>{
+//! use anyhow::anyhow;
 //! use nym_bridges::connection::{BridgeConn, SOCKET_OPEN_NOP};
-//! use nym_bridges::types::PersistedClientConfig;
+//! use nym_bridges::config::parse_persisted_config_json;
 //! use nym_bridges::forward::UdpForwarder;
 //! use tokio_util::sync::CancellationToken;
 //!
 //! let client_config_str = r#"{"version":"0","transports":[{"transport_type":"quic_plain","args":{"addresses":["139.162.33.226:4443","[2400:8901::2000:faff:fea6:87f2]:4443"],"host":"netdna.bootstrapcdn.com","id_pubkey":"9JC91ZiszhIn3n4FG+MDYE/lYwhGdpHGWQTKUqGl+sE="}}]}"#;
 //! let shutdown_token = CancellationToken::new();
 //! let entry_bridge_params = parse_persisted_config_json(client_config_str)?;
+//! let transport_params = entry_bridge_params
+//!     .transports
+//!     .first()
+//!     .ok_or(anyhow!("no config provided"))?;
 //!
 //! let bridge_conn = BridgeConn::try_connect(
-//!     entry_bridge_params.into(),
+//!     transport_params.clone(),
 //!     shutdown_token.clone(),
 //!     #[cfg(any(target_os = "linux", target_os = "android"))]
 //!     SOCKET_OPEN_NOP,
@@ -41,7 +48,7 @@
 //! .await?;
 //!
 //! let remote_addr = bridge_conn.endpoint();
-//! let (listen_addr, join_handle) = UdpForwarder::launch(
+//! let (listen_addr, join_handle) = UdpForwarder::launch_initiator(
 //!     bridge_conn,
 //!     None,
 //!     None,
@@ -50,6 +57,7 @@
 //! .await?;
 //!
 //! # Ok::<(), anyhow::Error>(())
+//! # }
 //! ```
 //!
 //! # Example: Parse and Convert Configuration


### PR DESCRIPTION
Abandon the adherance to camelCase for the `typescript-bindings` feature given the rist of causing compat issues down the road. 