### PR TITLE
Interface adjustment nym repo usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "serde_json",
  "ts-rs",
  "uniffi",
+ "utoipa",
 ]
 
 [[package]]
@@ -3049,6 +3050,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
+ "regex",
  "syn 2.0.119",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 ] }
 ts-rs = "12.0.1"
 uniffi = { version = "=0.31.1", features = ["cli"] }
+utoipa = "5.2"
+utoipauto = "0.2"
 uuid = "1.24"
 x509-parser = { version = "0.18", features = ["verify"] }
 webpki-roots = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 ts-rs = "12.0.1"
 uniffi = { version = "=0.31.1", features = ["cli"] }
 utoipa = "5.2"
-utoipauto = "0.2"
 uuid = "1.24"
 x509-parser = { version = "0.18", features = ["verify"] }
 webpki-roots = "1.0"

--- a/crates/nym-bridges-types/Cargo.toml
+++ b/crates/nym-bridges-types/Cargo.toml
@@ -15,6 +15,7 @@ license.workspace = true
 uniffi-bindings = ["dep:uniffi"]
 typescript-bindings = ["dep:ts-rs", "serde"]
 serde = ["dep:serde"]
+utoipa = ["dep:utoipa"]
 
 [dependencies]
 # bip39 = { workspace = true }
@@ -29,6 +30,7 @@ ts-rs = { workspace = true, optional = true }
 # zeroize.workspace = true
 # ipnetwork = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
+utoipa = { workspace = true, features = ["axum_extras", "time"], optional=true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/crates/nym-bridges-types/Cargo.toml
+++ b/crates/nym-bridges-types/Cargo.toml
@@ -18,17 +18,8 @@ serde = ["dep:serde"]
 utoipa = ["dep:utoipa"]
 
 [dependencies]
-# bip39 = { workspace = true }
-# si-scale = { workspace = true, features = ["lossy-conversions"] }
-# strum.workspace = true
-# strum_macros.workspace = true
-# time = { workspace = true, features = ["serde", "parsing", "formatting"] }
-# tracing = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
-# thiserror.workspace = true
 ts-rs = { workspace = true, optional = true }
-# zeroize.workspace = true
-# ipnetwork = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 utoipa = { workspace = true, features = ["axum_extras", "time"], optional=true }
 

--- a/crates/nym-bridges-types/src/lib.rs
+++ b/crates/nym-bridges-types/src/lib.rs
@@ -50,6 +50,19 @@ uniffi::custom_type!(BridgeSocketAddr, String, {
     lower: |val| val.to_string()
 });
 
+/// Whether this transport has sufficient details to dial: at least one address and a non-blank
+/// identity pin (the pin is what the certificate is verified against, so a transport without one is
+/// unusable regardless of addresses). Callers picking "any advertised transport" should filter on
+/// this — see [`PersistedClientConfig::usable_transports`].
+pub trait Sufficiency {
+    fn is_sufficient(&self) -> bool;
+}
+
+/// Trait allowing types to indicate the name of the transport type with which they are associated.
+pub trait TransportAssociation {
+    fn transport_name(&self) -> String;
+}
+
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
@@ -76,6 +89,13 @@ impl PersistedClientConfig {
             }
         }
         addrs
+    }
+
+    /// The transports that are actually usable (see [`ClientConfig::is_usable`]),
+    /// in the order they were listed. A caller wanting to dial "any advertised
+    /// transport" should try these in order rather than assuming a single one.
+    pub fn usable_transports(&self) -> impl Iterator<Item = &ClientConfig> {
+        self.transports.iter().filter(|t| t.is_sufficient())
     }
 }
 
@@ -108,13 +128,44 @@ impl From<tls::ClientOptions> for ClientConfig {
     }
 }
 
+impl ClientConfig {
+    /// Candidate bridge socket addresses, regardless of transport kind.
+    pub fn addresses(&self) -> &[BridgeSocketAddr] {
+        match self {
+            ClientConfig::QuicPlain(o) => &o.addresses,
+            ClientConfig::TlsPlain(o) => &o.addresses,
+        }
+    }
+}
+
+impl Sufficiency for ClientConfig {
+    fn is_sufficient(&self) -> bool {
+        match self {
+            ClientConfig::QuicPlain(o) => o.is_sufficient(),
+            ClientConfig::TlsPlain(o) => o.is_sufficient(),
+        }
+    }
+}
+
+impl TransportAssociation for ClientConfig {
+    fn transport_name(&self) -> String {
+        match self {
+            ClientConfig::QuicPlain(o) => o.transport_name(),
+            ClientConfig::TlsPlain(o) => o.transport_name(),
+        }
+    }
+}
+
 pub mod quic {
+    use crate::{Sufficiency, TransportAssociation};
     #[cfg(feature = "serde")]
     use serde::{Deserialize, Serialize};
     use std::net::SocketAddr as BridgeSocketAddr;
 
     #[cfg(feature = "typescript-bindings")]
     use ts_rs::TS;
+
+    pub const TRANSPORT_NAME: &str = "quic_plain";
 
     #[derive(Debug, PartialEq, Clone)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -143,16 +194,31 @@ pub mod quic {
         pub id_pubkey: String,
     }
 
+    impl Sufficiency for QuicPlainClientOptions {
+        fn is_sufficient(&self) -> bool {
+            !self.addresses.is_empty() && !self.id_pubkey.trim().is_empty()
+        }
+    }
+
+    impl TransportAssociation for QuicPlainClientOptions {
+        fn transport_name(&self) -> String {
+            TRANSPORT_NAME.to_string()
+        }
+    }
+
     pub type ClientOptions = QuicPlainClientOptions;
 }
 
 pub mod tls {
+    use crate::{Sufficiency, TransportAssociation};
     #[cfg(feature = "serde")]
     use serde::{Deserialize, Serialize};
     use std::net::SocketAddr as BridgeSocketAddr;
 
     #[cfg(feature = "typescript-bindings")]
     use ts_rs::TS;
+
+    pub const TRANSPORT_NAME: &str = "tls_plain";
 
     #[derive(Debug, PartialEq, Clone)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -179,6 +245,18 @@ pub mod tls {
 
         /// Use identity public key to verify server self signed certificate base64 encoded
         pub id_pubkey: String,
+    }
+
+    impl Sufficiency for TlsPlainClientOptions {
+        fn is_sufficient(&self) -> bool {
+            !self.addresses.is_empty() && !self.id_pubkey.trim().is_empty()
+        }
+    }
+
+    impl TransportAssociation for TlsPlainClientOptions {
+        fn transport_name(&self) -> String {
+            TRANSPORT_NAME.to_string()
+        }
     }
 
     pub type ClientOptions = TlsPlainClientOptions;

--- a/crates/nym-bridges-types/src/lib.rs
+++ b/crates/nym-bridges-types/src/lib.rs
@@ -53,6 +53,7 @@ uniffi::custom_type!(BridgeSocketAddr, String, {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "typescript-bindings",
     derive(TS),
@@ -82,6 +83,7 @@ impl PersistedClientConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "transport_type", content = "args"))]
 #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "typescript-bindings",
     derive(TS),
@@ -117,6 +119,7 @@ pub mod quic {
     #[derive(Debug, PartialEq, Clone)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+    #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
     #[cfg_attr(
         feature = "typescript-bindings",
         derive(TS),
@@ -130,6 +133,7 @@ pub mod quic {
         /// as the key material should not be used across multiple instances.
         ///
         /// Must parse as a valid [`std::net::SocketAddr`] - e.g. `123.45.67.89:443`
+        #[cfg_attr(feature = "utoipa", schema(value_type = Vec<String>))]
         pub addresses: Vec<BridgeSocketAddr>,
 
         /// Override hostname used for certificate verification
@@ -153,6 +157,7 @@ pub mod tls {
     #[derive(Debug, PartialEq, Clone)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+    #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
     #[cfg_attr(
         feature = "typescript-bindings",
         derive(TS),
@@ -166,6 +171,7 @@ pub mod tls {
         /// as the key material should not be used across multiple instances.
         ///
         /// Must parse as a valid [`std::net::SocketAddr`] - e.g. `123.45.67.89:443`
+        #[cfg_attr(feature = "utoipa", schema(value_type = Vec<String>))]
         pub addresses: Vec<BridgeSocketAddr>,
 
         /// Override hostname used for certificate verification

--- a/crates/nym-bridges/src/connection.rs
+++ b/crates/nym-bridges/src/connection.rs
@@ -77,4 +77,21 @@ impl BridgeConn {
     pub fn endpoint(&self) -> SocketAddr {
         self.endpoint
     }
+
+    /// The parameters this connection was built from.
+    pub fn params(&self) -> &ClientConfig {
+        &self.params
+    }
+
+    /// Split into the raw duplex halves of the transport stream, for callers
+    /// that want to frame it themselves (e.g. length-delimited datapath
+    /// packets) rather than going through [`crate::forward::UdpForwarder`].
+    pub fn into_parts(
+        self,
+    ) -> (
+        Box<dyn AsyncRead + Send + Unpin>,
+        Box<dyn AsyncWrite + Send + Unpin>,
+    ) {
+        (self.reader, self.writer)
+    }
 }

--- a/crates/nym-bridges/src/transport/quic/mod.rs
+++ b/crates/nym-bridges/src/transport/quic/mod.rs
@@ -129,7 +129,12 @@ impl TryFrom<&ClientOptions> for InnerClientOptions {
 
         Ok(Self {
             addresses: value.addresses.clone(),
-            host: value.host.clone(),
+            // Trim so a directory value padded with incidental whitespace still verifies as SNI.
+            host: value
+                .host
+                .as_deref()
+                .map(|h| h.trim().to_string())
+                .filter(|h| !h.is_empty()),
             id_pubkey,
         })
     }
@@ -138,8 +143,9 @@ impl TryFrom<&ClientOptions> for InnerClientOptions {
 impl InnerClientOptions {
     fn parse_base64_pubkey(key: impl AsRef<str>) -> Result<VerifyingKey, TransportError> {
         let mut pubkey_bytes = [0u8; 32];
+        // Trim so a directory value padded with incidental whitespace still base64-decodes.
         BASE64_STANDARD
-            .decode_slice(key.as_ref(), &mut pubkey_bytes)
+            .decode_slice(key.as_ref().trim(), &mut pubkey_bytes)
             .map_err(|e| {
                 TransportError::config_err(format!(
                     "failed to decode Quic bridge public key as base64: {e}"


### PR DESCRIPTION
Adjust interface used for nym-bridges based on usage in the [nymtech/nym](https://github.com/nymtech/nym) repo. This is meant to smooth usage and centralize types. This includes `nym-node-status-api` as well as `nym-smoldvpn` and `nym-sdk-session`.



- Functionality traits to make usage smoother 
  - `TransportAssociation` to indicate transport type name for associated types
  - `Sufficiency` to indicate that a config type has non-empty values for required fields such that it is sufficient to attempt a connection.
- Add `utoipa::ToSchema` to the `nym-bridges-types` 
- Add the ability to split a `BridgeConn` to a writer/reader pair
-  Add ability to get the transport params associated with a `BridgeConn`